### PR TITLE
Fix call to this.getChildHeight()

### DIFF
--- a/src/LazyRender.jsx
+++ b/src/LazyRender.jsx
@@ -134,7 +134,7 @@ var LazyRender = createReactClass({
     var childHeight = this.state.childHeight || 1;
     var childrenLength = this.getChildrenLength(nextProps);
 
-    if(!this.state.childHeight && this.getChildHeight){
+    if(!this.state.childHeight && this.getChildHeight()){
       childHeight = this.getChildHeight();
     }
 


### PR DESCRIPTION
I think there is a typo since the function always exists.
Instead, it should call the function to see if the child exists or not.